### PR TITLE
Fixes for simulator

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -6,10 +6,11 @@
 #include "image.h"
 #include "models/deep_mlp.hpp"
 
+Serial pc(USBTX, USBRX, 115200);
+
 #ifndef TARGET_SIMULATOR
 #include "FATFileSystem.h"
 #include "F413ZH_SD_BlockDevice.h"
-Serial pc(USBTX, USBRX, 115200);
 F413ZH_SD_BlockDevice bd;
 FATFileSystem fs("fs");
 #else

--- a/simconfig.json
+++ b/simconfig.json
@@ -1,12 +1,14 @@
 {
     "compiler-args": [
         "-std=c++11",
-        "--preload-file", "sdcard@/fs"
+        "--preload-file", "sdcard@/fs",
+        "--preload-file", "constants@/fs/constants"
     ],
     "emterpretify": true,
     "ignore": [
         "./BSP_DISCO_F413ZH",
-        "./F413ZH_SD_BlockDevice"
+        "./F413ZH_SD_BlockDevice",
+        "./utensor/sd-driver/"
     ],
     "peripherals": [
         { "component": "ST7789H2", "args": {} }


### PR DESCRIPTION
Don't compile sd-driver; move Serial declaration outside of ifdef

@neil-tan 